### PR TITLE
Leave fat JAR separate from library JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
 							</archive>
 							<finalName>libadsb-${version}-fat</finalName>
 							<appendAssemblyId>false</appendAssemblyId>
+							<attach>false</attach>
 							<descriptorRefs>
 								<descriptorRef>jar-with-dependencies</descriptorRef>
 							</descriptorRefs>


### PR DESCRIPTION
Current config results in the following warnings:
```
[WARNING] Configuration options: 'appendAssemblyId' is set to false, and 'classifier' is missing.
Instead of attaching the assembly file: /Users/wnagele/Desktop/java-adsb/target/libadsb-1.1-fat.jar, it will become the file for main project artifact.
NOTE: If multiple descriptors or descriptor-formats are provided for this project, the value of this file will be non-deterministic!
[WARNING] Replacing pre-existing project main-artifact file: /Users/wnagele/Desktop/java-adsb/target/libadsb-1.1.jar
with assembly file: /Users/wnagele/Desktop/java-adsb/target/libadsb-1.1-fat.jar
```

This results in the fat JAR replacing the library JAR. Just need to supply the attach=false option so we get both JARs.