### PR TITLE
Fix to global decode method of surface messages + other improvements

### DIFF
--- a/src/main/java/org/opensky/libadsb/PositionDecoder.java
+++ b/src/main/java/org/opensky/libadsb/PositionDecoder.java
@@ -235,10 +235,8 @@ public class PositionDecoder {
 		last_pos = ret;
 		last_time = time;
 
-		if (!reasonable) {
+		if (!reasonable)
 			num_reasonable = 0;
-			ret = null;
-		}
 		else if (num_reasonable++<2) // at least n good msgs before
 			ret = null;
 
@@ -431,10 +429,9 @@ public class PositionDecoder {
 		last_pos = ret;
 		last_time = time;
 
-		if (!reasonable) {
+		if (!reasonable)
 			num_reasonable = 0;
-			ret = null;
-		} else if (reasonable && num_reasonable++ < 2) // at least n good msgs before
+		else if (num_reasonable++ < 2) // at least n good msgs before
 			ret = null;
 
 		return ret;


### PR DESCRIPTION
This fork includes a fix to the Northern/Southern hemisphere ambiguity of the global decoding method of surface messages. There is also a fix in the check of decoded LAT/LON ranges.
The applicability of the global decoding method to surface messages is extended to those cases where an eve-odd pair of messages are 25 to 50 seconds appart, and speed is less than or equal to 25 kts, as stated by the standard.
The fork also makes minor improvements in the global decoding method of airborne/surfaces position messages by removing the dual (and unnecesary) Dlon0/Dlon1 decoding and carrying over only one decode with the appropriate message type.
Some minor casts are included to avoid implicit casts.